### PR TITLE
Add comment username anonymizing

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ This extension adds three new user rights:
 * `teamcomment` (which allows posting comments)
 * `teamcommentlinks` (which allows posting external links in comments)
 * `teamcommentadmin` (which allows deleting user-posted comments), e.g.
+* `teamcommentseeusernames` (which allows seeing usernames on comments, defaults to true)
 
 ```
 $wgGroupPermissions['sysop']['commentadmin'] = true;
@@ -48,6 +49,7 @@ Only logged in users can post comments.
 * `$wgTeamCommentsEnabled` - Whether the system is enabled on a global scale.  Provided so comments can be turned off while keeping the tags in pages
 * `$wgCommentsInRecentChanges` - by default, this variable is set to false. Set it to true to display comments log entries in Special:RecentChanges, too, in addition to the comments log at Special:Log/comments.
 * `$wgTeamCommentsCheatSheetLocation` - by default, this variable is set to false.  Set it to a location to have a a link in the comments section to a user specified cheat sheet
+* `$wgTeamCommentsUserPseudonymizer` - by default, this is false.  Set it to a callback that takes a username and returns a string, for overriding the anonymous user text that's outputed if `teamcommentseeusernames` is false
 
 ## Special Page
 

--- a/extension.json
+++ b/extension.json
@@ -18,7 +18,8 @@
   },
   "GroupPermissions": {
     "*": {
-      "teamcomment": true
+      "teamcomment": true,
+      "teamcommentseeusernames": true
     },
     "teamcommentadmin": {
       "teamcommentadmin": true
@@ -30,7 +31,8 @@
   "AvailableRights": [
     "teamcomment",
     "teamcommentadmin",
-    "teamcommentlinks"
+    "teamcommentlinks",
+    "teamcommentseeusernames"
   ],
   "LogTypes": [
     "teamcomments"
@@ -105,7 +107,8 @@
   "config": {
     "TeamCommentsEnabled": true,
     "TeamCommentsInRecentChanges": false,
-    "TeamCommentsCheatSheetLocation": false
+    "TeamCommentsCheatSheetLocation": false,
+    "TeamCommentsUserPseudonymizer": false
   },
   "manifest_version": 1
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -74,5 +74,7 @@
   "right-teamcommentadmin": "Administrate user-submitted comments",
   "action-teamcommentlinks": "use external links in comments",
   "right-teamcommentlinks": "Use external links in comments",
-  "teamcomments-special-teamcommentlist": "Team Comments List"
+  "teamcomments-special-teamcommentlist": "Team Comments List",
+  "teamcomments-anonymoususer": "Anonymous User",
+  "teamcomments-numberedanonymoususer": "Anonymous User #$1"
 }

--- a/includes/TeamComment.php
+++ b/includes/TeamComment.php
@@ -340,7 +340,7 @@ class TeamComment extends ContextSource {
    * @return string
    */
   function showTeamComment( $hide = false, $containerClass) {
-    global $wgExtensionAssetsPath, $wgLang, $wgUser;
+    global $wgExtensionAssetsPath, $wgLang, $wgUser, $wgTeamCommentsUserPseudonymizer;
 
     $style = '';
     if ( $hide ) {
@@ -348,9 +348,20 @@ class TeamComment extends ContextSource {
     }
 
     $title = Title::makeTitle( NS_USER, $this->username );
+    $user = User::newFromName($this->username);
 
-    $teamcommentPoster = '<a class="username" href="' . htmlspecialchars( $title->getFullURL() ) .
-      '" rel="nofollow">' . $this->username . '</a>';
+    if($wgUser->isAllowed('teamcommentseeusernames') || $wgUser->getId() == $user->getId()) {
+      $teamcommentPoster = '<a class="username" href="' . htmlspecialchars( $title->getFullURL() ) .
+        '" rel="nofollow">' . $this->username . '</a>';
+    } else {
+      if(!$user || $user->getId() == 0) {
+        $teamcommentPoster = $this->msg('teamcomments-anonymoususer');
+      } else if($wgTeamCommentsUserPseudonymizer) {
+        $teamcommentPoster = call_user_func($wgTeamCommentsUserPseudonymizer, $this->username);
+      } else {
+        $teamcommentPoster = wfMessage('teamcomments-numberedanonymoususer', $user->getId());
+      }
+    }
 
     $TeamCommentReplyTo = $this->username;
 


### PR DESCRIPTION
For certain classes of users, we need to not allow usernames in the
comments to be visible.  We also need a callback so that systems that
have other methods of creating the anonymous user can insert their
preferred text for the display.